### PR TITLE
Better error when staging profile is missing (#35)

### DIFF
--- a/src/main/scala/xerial/sbt/Sonatype.scala
+++ b/src/main/scala/xerial/sbt/Sonatype.scala
@@ -459,9 +459,9 @@ object Sonatype extends AutoPlugin {
       }
       if(repos.isEmpty) {
         if(stagingProfiles.isEmpty) {
-          log.error(s"No staging profile found for $profileName.")
+          log.error(s"No staging profile found for $profileName")
           log.error("Have you requested a staging profile and successfully published your signed artifact there?")
-          throw new IllegalStateException(s"No staging profile found for $profileName.")
+          throw new IllegalStateException(s"No staging profile found for $profileName")
         } else {
           throw new IllegalStateException(command.errNotFound)
         }

--- a/src/main/scala/xerial/sbt/Sonatype.scala
+++ b/src/main/scala/xerial/sbt/Sonatype.scala
@@ -457,8 +457,15 @@ object Sonatype extends AutoPlugin {
         case Drop => stagingRepositoryProfiles
         case CloseAndPromote => stagingRepositoryProfiles
       }
-      if(repos.isEmpty)
-        throw new IllegalStateException(command.errNotFound)
+      if(repos.isEmpty) {
+        if(stagingProfiles.isEmpty) {
+          log.error(s"No staging profile found for $profileName.")
+          log.error("Have you requested a staging profile and successfully published your signed artifact there?")
+          throw new IllegalStateException(s"No staging profile found for $profileName.")
+        } else {
+          throw new IllegalStateException(command.errNotFound)
+        }
+      }
 
       def findSpecifiedInArg(target: String) = {
         repos.find(_.repositoryId == target).getOrElse{


### PR DESCRIPTION
Would have been nice to add a unit test but a 'scripted' test seemed overkill.

Manually tested and seemed good:

Organization with no staging profile:
```
[info] Nexus repository URL: https://oss.sonatype.org/service/local
[info] sonatypeProfileName = net.bzztt
[info] Reading staging repository profiles...
[warn] No staging repository is found. Do publishSigned first.
[info] Reading staging profiles...
[error] No staging profile found for net.bzztt.
[error] Have you requested a staging profile and successfully published your signed artifact there?
java.lang.IllegalStateException: No staging profile found for net.bzztt.
	at xerial.sbt.Sonatype$NexusRESTService.findTargetRepository(Sonatype.scala:464)
	at xerial.sbt.Sonatype$SonatypeCommand$$anonfun$19.apply(Sonatype.scala:205)
	at xerial.sbt.Sonatype$SonatypeCommand$$anonfun$19.apply(Sonatype.scala:198)
	at sbt.Command$$anonfun$applyEffect$1$$anonfun$apply$2.apply(Command.scala:59)
	at sbt.Command$$anonfun$applyEffect$1$$anonfun$apply$2.apply(Command.scala:59)
	at sbt.Command$$anonfun$applyEffect$2$$anonfun$apply$3.apply(Command.scala:61)
	at sbt.Command$$anonfun$applyEffect$2$$anonfun$apply$3.apply(Command.scala:61)
	at sbt.Command$.process(Command.scala:93)
	at sbt.MainLoop$$anonfun$1$$anonfun$apply$1.apply(MainLoop.scala:96)
	at sbt.MainLoop$$anonfun$1$$anonfun$apply$1.apply(MainLoop.scala:96)
	at sbt.State$$anon$1.process(State.scala:184)
	at sbt.MainLoop$$anonfun$1.apply(MainLoop.scala:96)
	at sbt.MainLoop$$anonfun$1.apply(MainLoop.scala:96)
	at sbt.ErrorHandling$.wideConvert(ErrorHandling.scala:17)
	at sbt.MainLoop$.next(MainLoop.scala:96)
	at sbt.MainLoop$.run(MainLoop.scala:89)
	at sbt.MainLoop$$anonfun$runWithNewLog$1.apply(MainLoop.scala:68)
	at sbt.MainLoop$$anonfun$runWithNewLog$1.apply(MainLoop.scala:63)
	at sbt.Using.apply(Using.scala:24)
	at sbt.MainLoop$.runWithNewLog(MainLoop.scala:63)
	at sbt.MainLoop$.runAndClearLast(MainLoop.scala:46)
	at sbt.MainLoop$.runLoggedLoop(MainLoop.scala:30)
	at sbt.MainLoop$.runLogged(MainLoop.scala:22)
	at sbt.StandardMain$.runManaged(Main.scala:57)
	at sbt.xMain.run(Main.scala:29)
	at xsbt.boot.Launch$$anonfun$run$1.apply(Launch.scala:109)
	at xsbt.boot.Launch$.withContextLoader(Launch.scala:128)
	at xsbt.boot.Launch$.run(Launch.scala:109)
	at xsbt.boot.Launch$$anonfun$apply$1.apply(Launch.scala:35)
	at xsbt.boot.Launch$.launch(Launch.scala:117)
	at xsbt.boot.Launch$.apply(Launch.scala:18)
	at xsbt.boot.Boot$.runImpl(Boot.scala:41)
	at xsbt.boot.Boot$.main(Boot.scala:17)
	at xsbt.boot.Boot.main(Boot.scala)
[error] java.lang.IllegalStateException: No staging profile found for net.bzztt.
[error] Use 'last' for the full log.
➜  ectrace git:(master) ✗
```

Organization with staging profile but no published repo:
```
[info] Nexus repository URL: https://oss.sonatype.org/service/local
[info] sonatypeProfileName = net.bzzt
[info] Reading staging repository profiles...
[warn] No staging repository is found. Do publishSigned first.
[info] Reading staging profiles...
java.lang.IllegalStateException: No staging repository is found. Run publishSigned first
	at xerial.sbt.Sonatype$NexusRESTService.findTargetRepository(Sonatype.scala:466)
	at xerial.sbt.Sonatype$SonatypeCommand$$anonfun$19.apply(Sonatype.scala:205)
	at xerial.sbt.Sonatype$SonatypeCommand$$anonfun$19.apply(Sonatype.scala:198)
	at sbt.Command$$anonfun$applyEffect$1$$anonfun$apply$2.apply(Command.scala:59)
	at sbt.Command$$anonfun$applyEffect$1$$anonfun$apply$2.apply(Command.scala:59)
	at sbt.Command$$anonfun$applyEffect$2$$anonfun$apply$3.apply(Command.scala:61)
	at sbt.Command$$anonfun$applyEffect$2$$anonfun$apply$3.apply(Command.scala:61)
	at sbt.Command$.process(Command.scala:93)
	at sbt.MainLoop$$anonfun$1$$anonfun$apply$1.apply(MainLoop.scala:96)
	at sbt.MainLoop$$anonfun$1$$anonfun$apply$1.apply(MainLoop.scala:96)
	at sbt.State$$anon$1.process(State.scala:184)
	at sbt.MainLoop$$anonfun$1.apply(MainLoop.scala:96)
	at sbt.MainLoop$$anonfun$1.apply(MainLoop.scala:96)
	at sbt.ErrorHandling$.wideConvert(ErrorHandling.scala:17)
	at sbt.MainLoop$.next(MainLoop.scala:96)
	at sbt.MainLoop$.run(MainLoop.scala:89)
	at sbt.MainLoop$$anonfun$runWithNewLog$1.apply(MainLoop.scala:68)
	at sbt.MainLoop$$anonfun$runWithNewLog$1.apply(MainLoop.scala:63)
	at sbt.Using.apply(Using.scala:24)
	at sbt.MainLoop$.runWithNewLog(MainLoop.scala:63)
	at sbt.MainLoop$.runAndClearLast(MainLoop.scala:46)
	at sbt.MainLoop$.runLoggedLoop(MainLoop.scala:30)
	at sbt.MainLoop$.runLogged(MainLoop.scala:22)
	at sbt.StandardMain$.runManaged(Main.scala:57)
	at sbt.xMain.run(Main.scala:29)
	at xsbt.boot.Launch$$anonfun$run$1.apply(Launch.scala:109)
	at xsbt.boot.Launch$.withContextLoader(Launch.scala:128)
	at xsbt.boot.Launch$.run(Launch.scala:109)
	at xsbt.boot.Launch$$anonfun$apply$1.apply(Launch.scala:35)
	at xsbt.boot.Launch$.launch(Launch.scala:117)
	at xsbt.boot.Launch$.apply(Launch.scala:18)
	at xsbt.boot.Boot$.runImpl(Boot.scala:41)
	at xsbt.boot.Boot$.main(Boot.scala:17)
	at xsbt.boot.Boot.main(Boot.scala)
[error] java.lang.IllegalStateException: No staging repository is found. Run publishSigned first
[error] Use 'last' for the full log.
➜  ectrace git:(master) ✗
```