### PR TITLE
Revert recommendation of `releasePublishArtifactsAction` for signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,6 @@ To perform publishSigned and sonatypeReleaseAll with [sbt-release](https://githu
 import ReleaseTransformations._
 
 releaseCrossBuild := true // true if you cross-build the project for multiple Scala versions
-releasePublishArtifactsAction := PgpKeys.publishSigned.value // Use publishSigned in publishArtifacts step
 releaseProcess := Seq[ReleaseStep](
   checkSnapshotDependencies,
   inquireVersions,
@@ -180,7 +179,7 @@ releaseProcess := Seq[ReleaseStep](
   setReleaseVersion,
   commitReleaseVersion,
   tagRelease,
-  publishArtifacts,
+  releaseStepCommand("publishSigned"),
   setNextVersion,
   commitNextVersion,
   releaseStepCommand("sonatypeReleaseAll"),


### PR DESCRIPTION
Unfortunately this configuration (using `releasePublishArtifactsAction`) doesn't work with multi-module projects - the setting does not seem to take effect, the signing action is not taken, and the subsequent `sonatypeReleaseAll` fails on closing the staging repository, eg:

```
[info] repositoryCloseFailed: id:commadgag-1154, cause:com.sonatype.nexus.staging.StagingRulesFailedException: One or more rules have failed
[error] Failed to close the repository
[error] Activity close started:2017-08-26T23:10:02.013Z, stopped:2017-08-26T23:10:13.267Z
[error]     Failed: signature-staging, failureMessage:Missing Signature: '/com/madgag/scala-git/scala-git_2.10/3.5/scala-git_2.10-3.5-javadoc.jar.asc' does not exist for 'scala-git_2.10-3.5-javadoc.jar'.
[error] java.lang.Exception: Failed to close the repository
[error] 	at xerial.sbt.Sonatype$NexusRESTService.closeStage(Sonatype.scala:721)
[error] 	at xerial.sbt.Sonatype$NexusRESTService.closeAndPromote(Sonatype.scala:820)
[error] 	at xerial.sbt.Sonatype$SonatypeCommand$.$anonfun$sonatypeReleaseAll$2(Sonatype.scala:215)
```

This problem was fixed for me by reverting to the old configuration, ie in https://github.com/rtyley/scala-io/commit/fc82246b