### PR TITLE
Add shortcut for pomExtra fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,11 @@ licenses := Seq("APL2" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt"))
 
 // Where is the source code hosted
 import xerial.sbt.Sonatype._
-sonatypeProjectHosting := Some(GithubHosting("username", "repostoryName"))
+sonatypeProjectHosting := Some(GithubHosting("username", "projectName", "user@example.com"))
+// or
+sonatypeProjectHosting := Some(GitlabHosting("username", "projectName", "user@example.com"))
 
-// or alternatively 
+// or if you want to set these fields manually
 homepage := Some(url("https://(your project url)"))
 scmInfo := Some(
   ScmInfo(

--- a/README.md
+++ b/README.md
@@ -89,9 +89,9 @@ licenses := Seq("APL2" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt"))
 
 // Where is the source code hosted
 import xerial.sbt.Sonatype._
-sonatypeProjectHosting := Some(GithubHosting("username", "projectName", "user@example.com"))
+sonatypeProjectHosting := Some(GitHubHosting("username", "projectName", "user@example.com"))
 // or
-sonatypeProjectHosting := Some(GitlabHosting("username", "projectName", "user@example.com"))
+sonatypeProjectHosting := Some(GitLabHosting("username", "projectName", "user@example.com"))
 
 // or if you want to set these fields manually
 homepage := Some(url("https://(your project url)"))

--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ publishMavenStyle := true
 
 // License of your choice
 licenses := Seq("APL2" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt"))
+
+// Where is the source code hosted
+import xerial.sbt.Sonatype._
+sonatypeProjectHosting := Some(GithubHosting("username", "repostoryName"))
+
+// or alternatively 
 homepage := Some(url("https://(your project url)"))
 scmInfo := Some(
   ScmInfo(

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,7 @@
 Release Notes
 ===
+# 2.1
+- Add shortcut `sonatypeProjectHosting` for quickly setting `homepage`, `scmInfo` and `developers`
 
 # 2.0 
 - Support sbt-0.13, 1.0.0-M5, 1.0.0-M6, and 1.0.0-RC3

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.3
+sbt.version=1.1.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
-addSbtPlugin("com.github.gseitz" % "sbt-release"  % "1.0.6")
+addSbtPlugin("com.github.gseitz" % "sbt-release"  % "1.0.7")
 addSbtPlugin("org.xerial.sbt"    % "sbt-sonatype" % "2.0")
 addSbtPlugin("com.jsuereth"      % "sbt-pgp"      % "1.1.0")
-addSbtPlugin("io.get-coursier"   % "sbt-coursier" % "1.0.0-RC12")
+addSbtPlugin("io.get-coursier"   % "sbt-coursier" % "1.0.0")
 addSbtPlugin("com.geirsson"      % "sbt-scalafmt" % "1.3.0")
 
 libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value

--- a/src/main/scala/xerial/sbt/Sonatype.scala
+++ b/src/main/scala/xerial/sbt/Sonatype.scala
@@ -84,16 +84,22 @@ object Sonatype extends AutoPlugin {
   sealed trait ProjectHosting {
     def homepage: String
     def scmUrl: String
+    def developer: Developer
     def scmInfo                     = ScmInfo(url(homepage), scmUrl)
     def developers: List[Developer] = List(developer)
-    def developer: Developer
   }
 
-  case class GithubHosting(user: String, repository: String) extends ProjectHosting {
-    def homepage  = s"https://github.com/$user/$repository"
-    def scmUrl    = s"git@github.com:$user/$repository.git"
-    def developer = Developer(user, user, s"$user@notadomain.com", url(s"https://github.com/$user"))
+  abstract class BaseHosting(domain: String) extends ProjectHosting {
+    def user: String
+    def email: String
+    def repository: String
+    def homepage  = s"https://$domain/$user/$repository"
+    def scmUrl    = s"git@$domain:$user/$repository.git"
+    def developer = Developer(user, user, email, url(s"https://$domain/$user"))
   }
+
+  case class GithubHosting(user: String, repository: String, email: String) extends BaseHosting("github.com")
+  case class GitlabHosting(user: String, repository: String, email: String) extends BaseHosting("gitlab.com")
 
   object SonatypeCommand {
     import complete.DefaultParsers._

--- a/src/main/scala/xerial/sbt/Sonatype.scala
+++ b/src/main/scala/xerial/sbt/Sonatype.scala
@@ -59,7 +59,11 @@ object Sonatype extends AutoPlugin {
     },
     homepage := sonatypeProjectHosting.value.map(h => url(h.homepage)).orElse(homepage.value),
     scmInfo := sonatypeProjectHosting.value.map(_.scmInfo).orElse(scmInfo.value),
-    developers := sonatypeProjectHosting.value.map(_.developers).orElse(Some(developers.value)).getOrElse(List.empty),
+    developers := {
+      val derived = sonatypeProjectHosting.value.map(_.developers).getOrElse(List.empty)
+      if (developers.value.isEmpty) derived
+      else developers.value
+    },
     sonatypeDefaultResolver := {
       if (isSnapshot.value) {
         Opts.resolver.sonatypeSnapshots

--- a/src/main/scala/xerial/sbt/Sonatype.scala
+++ b/src/main/scala/xerial/sbt/Sonatype.scala
@@ -98,8 +98,8 @@ object Sonatype extends AutoPlugin {
     def developer = Developer(user, user, email, url(s"https://$domain/$user"))
   }
 
-  case class GithubHosting(user: String, repository: String, email: String) extends BaseHosting("github.com")
-  case class GitlabHosting(user: String, repository: String, email: String) extends BaseHosting("gitlab.com")
+  case class GitHubHosting(user: String, repository: String, email: String) extends BaseHosting("github.com")
+  case class GitLabHosting(user: String, repository: String, email: String) extends BaseHosting("gitlab.com")
 
   object SonatypeCommand {
     import complete.DefaultParsers._

--- a/src/main/scala/xerial/sbt/Sonatype.scala
+++ b/src/main/scala/xerial/sbt/Sonatype.scala
@@ -57,7 +57,7 @@ object Sonatype extends AutoPlugin {
     pomIncludeRepository := { _ =>
       false
     },
-    homepage := sonatypeProjectHosting.value.map(h => url(h.homepage)).orElse(homepage.value),
+    homepage := homepage.value.orElse(sonatypeProjectHosting.value.map(h => url(h.homepage))),
     scmInfo := sonatypeProjectHosting.value.map(_.scmInfo).orElse(scmInfo.value),
     developers := {
       val derived = sonatypeProjectHosting.value.map(h => List(h.developer)).getOrElse(List.empty)


### PR DESCRIPTION
This PR makes it easier to set pomExtra fields homepage, developers and scmInfo.

Instead of setting these fields directly, you can do the following:

```
sonatypeProjectHosting := Some(GithubHosting("xerial", "sbt-sonatype", "xerial@example.com"))
```
The same is possible for Gitlab and more shortcuts can be added.

The property name `sonatypeProjectHosting` might be a little misleading because it's actually not Sonatype-related. I'm open to suggestions.