### PR TITLE
Correct capitalisation for GitHub, GitLab

### DIFF
--- a/src/main/scala/xerial/sbt/Sonatype.scala
+++ b/src/main/scala/xerial/sbt/Sonatype.scala
@@ -108,17 +108,23 @@ object Sonatype extends AutoPlugin {
     def developer = Developer(user, fullName.getOrElse(user), email, url(s"https://$domain/$user"))
   }
 
-  object GithubHosting {
+  object GitHubHosting {
     private val domain                                                           = "github.com"
     def apply(user: String, repository: String, email: String)                   = ProjectHosting(domain, user, None, email, repository)
     def apply(user: String, repository: String, fullName: String, email: String) = ProjectHosting(domain, user, Some(fullName), email, repository)
   }
 
-  object GitlabHosting {
+  object GitLabHosting {
     private val domain                                                           = "gitlab.com"
     def apply(user: String, repository: String, email: String)                   = ProjectHosting(domain, user, None, email, repository)
     def apply(user: String, repository: String, fullName: String, email: String) = ProjectHosting(domain, user, Some(fullName), email, repository)
   }
+
+  // aliases
+  @deprecated("Use GitHubHosting (capital H) instead", "2.2")
+  val GithubHosting = GitHubHosting
+  @deprecated("Use GitLabHosting (capital L) instead", "2.2")
+  val GitlabHosting = GitLabHosting
 
   object SonatypeCommand {
     import complete.DefaultParsers._


### PR DESCRIPTION
I'm so sorry, but I made a mistake in my PR #58: You asked for the correct capitalisation for GitHub and GitLab, however I must have missed the incorrect spelling.

This PR fixes the spelling, adds backwards-compatible aliases and a deprecation warning.

Again, sorry for the oversight.