### PR TITLE
Allow setting the credentials through environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,8 @@ credentials += Credentials("Sonatype Nexus Repository Manager",
         "(Sonatype password)")
 ```
 
+Alternatively, the credentials can also be set with the environment variables `SONATYPE_USERNAME` and `SONATYPE_PASSWORD`.
+
 Then, run `sonatypeReleaseAll` command by specifying your `sonatypeProfileName`. If this is `org.xerial`, run:
 ```
 $ sbt "sonatypeReleaseAll org.xerial"

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,8 @@
 Release Notes
 ===
+# 2.3
+- Allow setting the credentials with the environment variables `SONATYPE_USERNAME` and `SONATYPE_PASSWORD`
+
 # 2.2
 - Fixes typo [#61](https://github.com/xerial/sbt-sonatype/pull/61) in GitHubHosting and GitLabHosting capitilization
 - If you are not using these keys, no need to upgrade to this version.

--- a/src/main/scala/xerial/sbt/Sonatype.scala
+++ b/src/main/scala/xerial/sbt/Sonatype.scala
@@ -63,8 +63,8 @@ object Sonatype extends AutoPlugin {
       if (!alreadyContainsSonatypeCredentials) {
         val env = sys.env.get(_)
         (for {
-          username <- env("SONATYPE_USERNAME").orElse(env("SONATYPE_USER"))
-          password <- env("SONATYPE_PASSWORD").orElse(env("SONATYPE_PASS"))
+          username <- env("SONATYPE_USERNAME")
+          password <- env("SONATYPE_PASSWORD")
         } yield
           Credentials(
             "Sonatype Nexus Repository Manager",

--- a/src/main/scala/xerial/sbt/Sonatype.scala
+++ b/src/main/scala/xerial/sbt/Sonatype.scala
@@ -58,6 +58,22 @@ object Sonatype extends AutoPlugin {
     pomIncludeRepository := { _ =>
       false
     },
+    credentials ++= {
+      val alreadyContainsSonatypeCredentials = credentials.value.collect { case d: DirectCredentials => d.host == sonatypeCredentialHost.value }.nonEmpty
+      if (!alreadyContainsSonatypeCredentials) {
+        val env = sys.env.get(_)
+        (for {
+          username <- env("SONATYPE_USERNAME").orElse(env("SONATYPE_USER"))
+          password <- env("SONATYPE_PASSWORD").orElse(env("SONATYPE_PASS"))
+        } yield
+          Credentials(
+            "Sonatype Nexus Repository Manager",
+            sonatypeCredentialHost.value,
+            username,
+            password
+          )).toSeq
+      } else Seq.empty
+    },
     homepage := homepage.value.orElse(sonatypeProjectHosting.value.map(h => url(h.homepage))),
     scmInfo := sonatypeProjectHosting.value.map(_.scmInfo).orElse(scmInfo.value),
     developers := {


### PR DESCRIPTION
Why is this useful?

Because on Travis and other platforms it is easier to set an env variable than to write a file to disk.

See https://github.com/leonardehrenfried/imgix-url-scala/blob/master/build.sbt#L65