### PR TITLE
sonatypeOpen should override repository inferred from isSnapshot

### DIFF
--- a/src/main/scala/xerial/sbt/Sonatype.scala
+++ b/src/main/scala/xerial/sbt/Sonatype.scala
@@ -86,16 +86,16 @@ object Sonatype extends AutoPlugin {
       val sonatypeRepo = "https://oss.sonatype.org/"
       val profileM     = sonatypeStagingRepositoryProfile.?.value
 
-      if (isSnapshot.value) {
+      val staged = profileM.map { stagingRepoProfile =>
+        "releases" at sonatypeRepo +
+          "service/local/staging/deployByRepositoryId/" +
+          stagingRepoProfile.repositoryId
+      }
+      staged.getOrElse(if (isSnapshot.value) {
         Opts.resolver.sonatypeSnapshots
       } else {
-        val staged = profileM.map { stagingRepoProfile =>
-          "releases" at sonatypeRepo +
-            "service/local/staging/deployByRepositoryId/" +
-            stagingRepoProfile.repositoryId
-        }
-        staged.getOrElse(Opts.resolver.sonatypeStaging)
-      }
+        Opts.resolver.sonatypeStaging
+      })
     },
     commands ++= Seq(
       sonatypeList,


### PR DESCRIPTION
Some other plug-in, including `sbt-dynver` and `sbt-release-early` will set `isSnapshot` to `true` for versions that does not end with `-SNAPSHOT`. 

With the help of this PR, people who want to publish those versions on staging repositories can use `sonatypeOpen` to override the snapshot repository URL.