### PR TITLE
Don't use isSnapshot because it is not reliable (fix #95)

### DIFF
--- a/src/main/scala/xerial/sbt/Sonatype.scala
+++ b/src/main/scala/xerial/sbt/Sonatype.scala
@@ -90,7 +90,7 @@ object Sonatype extends AutoPlugin {
       IO.delete(sonatypeBundleDirectory.value)
     },
     sonatypePublishToBundle := {
-      if (isSnapshot.value) {
+      if (version.value.endsWith("-SNAPSHOT")) {
         Some(Opts.resolver.sonatypeSnapshots)
       } else {
         Some(Resolver.file("sonatype-local-bundle", sonatypeBundleDirectory.value))
@@ -102,7 +102,7 @@ object Sonatype extends AutoPlugin {
       val staged = profileM.map { stagingRepoProfile =>
         "releases" at stagingRepoProfile.deployUrl
       }
-      staged.getOrElse(if (isSnapshot.value) {
+      staged.getOrElse(if (version.value.endsWith("-SNAPSHOT")) {
         Opts.resolver.sonatypeSnapshots
       } else {
         Opts.resolver.sonatypeStaging


### PR DESCRIPTION
sbt-dynver can set isSnapshot to true even when the version is not able to upload to sonatype snapshot repository.