### PR TITLE
Making alreadyContainsSonatypeCredentials work

### DIFF
--- a/src/main/scala/xerial/sbt/Sonatype.scala
+++ b/src/main/scala/xerial/sbt/Sonatype.scala
@@ -58,9 +58,10 @@ object Sonatype extends AutoPlugin {
       false
     },
     credentials ++= {
-      val alreadyContainsSonatypeCredentials = credentials.value.collect {
+      val alreadyContainsSonatypeCredentials: Boolean = credentials.value.exists {
         case d: DirectCredentials => d.host == sonatypeCredentialHost.value
-      }.nonEmpty
+        case _ => false
+      }
       if (!alreadyContainsSonatypeCredentials) {
         val env = sys.env.get(_)
         (for {


### PR DESCRIPTION
So, when switching from `sbt-pgp` to `sbt-gpg`, it became possible to explicitly select which key in particular I'd like to use to sign. This is configured through `Credentials`.

Unfortunately, due to the way `alreadyContainsSonatypeCredentials` works currently, _any_ `DirectCredentials` is accepted, with the resulting type after `collect` being `Seq[Boolean]`, so even if we end up with a `Seq(false)`, the `nonEmpty` still flips it to `true`.

What we _want_ is `exists`, to ensure that all elements are processed, and a single `Boolean` is returned, representing whether we found something that matched expectations.