### PR TITLE
Add timeout configuration

### DIFF
--- a/src/main/scala/xerial/sbt/Sonatype.scala
+++ b/src/main/scala/xerial/sbt/Sonatype.scala
@@ -34,6 +34,13 @@ object Sonatype extends AutoPlugin {
     val sonatypeBundleClean     = taskKey[Unit]("Clean up the local bundle folder")
     val sonatypeBundleDirectory = settingKey[File]("Directory to create a bundle")
     val sonatypeBundleRelease   = taskKey[String]("Release a bundle to Sonatype")
+
+    val sonatypeSocketTimeout = settingKey[Option[Int]](
+      "Timeout in milliseconds for waiting for data. i.e.. maximum period inactivity between two consecutive data packets"
+    )
+    val sonatypeConnectionTimeout = settingKey[Option[Int]](
+      "Timeout in milliseconds until a connection is established."
+    )
   }
 
   object SonatypeKeys extends SonatypeKeys {}
@@ -372,7 +379,11 @@ object Sonatype extends AutoPlugin {
       extracted.get(sonatypeRepository),
       profileName.getOrElse(extracted.get(sonatypeProfileName)),
       getCredentials(extracted, state),
-      extracted.get(sonatypeCredentialHost)
+      extracted.get(sonatypeCredentialHost),
+      NexusRESTService.TimeoutConfig(
+        socketSeconds = extracted.get(sonatypeSocketTimeout),
+        connectionSeconds = extracted.get(sonatypeConnectionTimeout)
+      )
     )
   }
 


### PR DESCRIPTION
Closes #133 

Fortunately, [Apache HttpClient offers 3 types of timeout configuration](https://hc.apache.org/httpcomponents-client-4.5.x/tutorial/html/connmgmt.html):

1. `http.socket.timeout`
2. `http.connection.timeout`
3. `http.conn-manager.timeout`: This is for multithreaded requests situation, which seems not applicable for sbt-sonatype, IIUC.

This PR exposes (1) socket timeout and (2) connection timeout.
Values are given to http client only if explicitly configured.
So I think this is NOT going to be a breacking change.

Sorry, not tested at all, since I could not figure how to test this feature.