### PR TITLE
add support for nexus backoff retry settings

### DIFF
--- a/src/main/scala/xerial/sbt/NexusBackOffRetrySettings.scala
+++ b/src/main/scala/xerial/sbt/NexusBackOffRetrySettings.scala
@@ -1,0 +1,3 @@
+package xerial.sbt
+
+case class NexusBackOffRetrySettings(initialWaitSeq: Int = 5, intervalSeq: Int = 3, maxRetries: Int = 10)

--- a/src/main/scala/xerial/sbt/Sonatype.scala
+++ b/src/main/scala/xerial/sbt/Sonatype.scala
@@ -29,7 +29,8 @@ object Sonatype extends AutoPlugin {
     val sonatypeTargetRepositoryProfile = settingKey[StagingRepositoryProfile]("Stating repository profile")
     val sonatypeProjectHosting =
       settingKey[Option[ProjectHosting]]("Shortcut to fill in required Maven Central information")
-    val sonatypeSessionName = settingKey[String]("Used for identifying a sonatype staging repository")
+    val sonatypeSessionName               = settingKey[String]("Used for identifying a sonatype staging repository")
+    val sonatypeNexusBackOffRetrySettings = settingKey[NexusBackOffRetrySettings]("nexus backOff retry settings")
 
     val sonatypeBundleClean     = taskKey[Unit]("Clean up the local bundle folder")
     val sonatypeBundleDirectory = settingKey[File]("Directory to create a bundle")
@@ -372,7 +373,8 @@ object Sonatype extends AutoPlugin {
       extracted.get(sonatypeRepository),
       profileName.getOrElse(extracted.get(sonatypeProfileName)),
       getCredentials(extracted, state),
-      extracted.get(sonatypeCredentialHost)
+      extracted.get(sonatypeCredentialHost),
+      extracted.get(sonatypeNexusBackOffRetrySettings)
     )
   }
 

--- a/src/main/scala/xerial/sbt/Sonatype.scala
+++ b/src/main/scala/xerial/sbt/Sonatype.scala
@@ -30,7 +30,7 @@ object Sonatype extends AutoPlugin {
     val sonatypeProjectHosting =
       settingKey[Option[ProjectHosting]]("Shortcut to fill in required Maven Central information")
     val sonatypeSessionName               = settingKey[String]("Used for identifying a sonatype staging repository")
-    val sonatypeNexusBackOffRetrySettings = settingKey[NexusBackOffRetrySettings]("nexus backOff retry settings")
+    val sonatypeNexusBackOffRetrySettings = settingKey[NexusBackOffRetrySettings]("nexus back-off retry settings")
 
     val sonatypeBundleClean     = taskKey[Unit]("Clean up the local bundle folder")
     val sonatypeBundleDirectory = settingKey[File]("Directory to create a bundle")


### PR DESCRIPTION
Hi.
In my sbt project, `Timed out` occurs. I think the reason is the large number of JAR files to deploy.
Tentatively could it be possible to adjust the back-off setting, like this P-R?

reproducible project: https://github.com/j5ik2o/reactive-aws-clients

```
[info] Promoting staging repository [comgithubj5ik2o-XXXX] status:closed, profile:com.github.j5ik2o(XXXXXXXXXXXX) description: [sbt-sonatype] reactive-aws-client-project 1.2.0
[info] Activity name:release, started:2020-03-25T17:46:31.328Z
[info]   Evaluate: id:nx-internal-ruleset, rule:RepositoryWritePolicy
[info]   Evaluate: RepositoryWritePolicy
[info] The release process is in progress ...
[info]     Passed: RepositoryWritePolicy
[info]     Passed: id:nx-internal-ruleset
[info]  copyItems: source:comgithubj5ik2o-1155, target:releases
[info] The release process is in progress ...
[info] The release process is in progress ...
[info] The release process is in progress ...
[info] The release process is in progress ...
[info] The release process is in progress ...
[info] The release process is in progress ...
[info] The release process is in progress ...
[info] The release process is in progress ...
[error] java.io.IOException: Timed out
[error] Use 'last' for the full log.
````