### PR TITLE
Update the sbt-pgp version in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ commands:
 ```scala
 // For sbt 1.x (sbt-sonatype 2.3 or higher)
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "(version)")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0-M2")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
 
 // For sbt 0.13.x (upto sbt-sonatype 2.3)
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "(version)")


### PR DESCRIPTION
I keep seeing the 2.0.0-M2 everywhere, and I think it's because people tend to copy paste without checking the latest version.

This is my attempt at solving the issue :)