### PR TITLE
Take only first 2 parts of a groupId as `sonatypeProfileName`

### DIFF
--- a/src/main/scala/xerial/sbt/Sonatype.scala
+++ b/src/main/scala/xerial/sbt/Sonatype.scala
@@ -54,7 +54,7 @@ object Sonatype extends AutoPlugin with LogSupport {
   private implicit val ec = ExecutionContext.global
 
   lazy val sonatypeSettings = Seq[Def.Setting[_]](
-    sonatypeProfileName := organization.value,
+    sonatypeProfileName := organizationToProfileName(organization.value),
     sonatypeRepository := "https://oss.sonatype.org/service/local",
     sonatypeCredentialHost := "oss.sonatype.org",
     sonatypeProjectHosting := None,
@@ -420,4 +420,16 @@ object Sonatype extends AutoPlugin with LogSupport {
   private def commandWithRepositoryId(name: String, briefHelp: String) =
     Command(name, (name, briefHelp), briefHelp)(_ => repositoryIdParser)(_)
 
+  private def organizationToProfileName(organization: String): String = {
+    val parts = organization.split('.').toList
+    val profile = parts match {
+      case "com" :: "github" :: _ => parts.take(3)
+      case "io" :: "github" :: _  => parts.take(3)
+      case "com" :: "gitlab" :: _ => parts.take(3)
+      case "io" :: "gitlab" :: _  => parts.take(3)
+      case "uk" :: _              => parts.take(3)
+      case _                      => parts.take(2)
+    }
+    profile.mkString(".")
+  }
 }

--- a/src/test/scala/xerial/sbt/sonatype/SonatypeClientTest.scala
+++ b/src/test/scala/xerial/sbt/sonatype/SonatypeClientTest.scala
@@ -4,6 +4,7 @@ import wvlet.airframe.codec.{JSONCodec, MessageCodec}
 import wvlet.airframe.msgpack.spi.MessagePack
 import wvlet.airspec.AirSpec
 import wvlet.log.io.IOUtil
+import xerial.sbt.Sonatype
 import xerial.sbt.sonatype.SonatypeClient.StagingProfileResponse;
 
 /**
@@ -23,5 +24,17 @@ class SonatypeClientTest extends AirSpec {
     unpacked.data.size shouldBe 2
 
     profile shouldBe unpacked
+  }
+  test("topLevelGroupId com.company.project.product = com.company") {
+    val groupId  = "com.company.project.product"
+    val expected = "com.company"
+    val actual   = Sonatype.topLevelGroupId(groupId)
+    actual shouldBe expected
+  }
+  test("topLevelGroupId io.gitlab.team.project = io.gitlab.team") {
+    val groupId  = "io.gitlab.team.project"
+    val expected = "io.gitlab.team"
+    val actual   = Sonatype.topLevelGroupId(groupId)
+    actual shouldBe expected
   }
 }


### PR DESCRIPTION
This is the prefered way as per https://issues.sonatype.org/browse/OSSRH-60402?focusedCommentId=964966&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-964966