### PR TITLE
Always use ThisBuild version for sonatypeBundleDirectory

### DIFF
--- a/src/main/scala/xerial/sbt/Sonatype.scala
+++ b/src/main/scala/xerial/sbt/Sonatype.scala
@@ -89,7 +89,7 @@ object Sonatype extends AutoPlugin with LogSupport {
     },
     sonatypePublishTo := Some(sonatypeDefaultResolver.value),
     sonatypeBundleDirectory := {
-      (ThisBuild / baseDirectory).value / "target" / "sonatype-staging" / s"${version.value}"
+      (ThisBuild / baseDirectory).value / "target" / "sonatype-staging" / s"${(ThisBuild / version).value}"
     },
     sonatypeBundleClean := {
       IO.delete(sonatypeBundleDirectory.value)


### PR DESCRIPTION
Fixes #197

Changes `sonatypeBundleDirectory` to always use the version directory of the root project.

Before:

```
sbt:root> version
[info] module-a / version
[info]  1.4.1
[info] module-b / version
[info]  1.4.0
[info] version
[info]  1.4.0
sbt:root> sonatypeBundleDirectory
[info] module-a / sonatypeBundleDirectory
[info]  /root/target/sonatype-staging/1.4.1
[info] module-b / sonatypeBundleDirectory
[info]  /root/target/sonatype-staging/1.4.0
[info] sonatypeBundleDirectory
[info]  /root/target/sonatype-staging/1.4.0
```

After:

```
sbt:root> version
[info] module-a / version
[info]  1.4.1
[info] module-b / version
[info]  1.4.0
[info] version
[info]  1.4.0
sbt:root> sonatypeBundleDirectory
[info] module-a / sonatypeBundleDirectory
[info]  /root/target/sonatype-staging/1.4.0
[info] module-b / sonatypeBundleDirectory
[info]  /root/target/sonatype-staging/1.4.0
[info] sonatypeBundleDirectory
[info]  /root/target/sonatype-staging/1.4.0
```