### PR TITLE
Fix hard coded Sonatype URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ A sbt plugin for publishing your project to the Maven central repository through
      * Create a GPG key
      * Open a JIRA ticket to get a permission for synchronizing your project to the Central Repository (aka Maven Central).
 
+   > ⚠️ Legacy Host
+   >
+   > By default, this plugin is configured to use the legacy Sonatype Nexus repository.
+   > Nexus accounts created on or after February 2021 are provisioned using the new host `s01.oss.sonatype.org`.
+   >
+   > If you are creating a new account take care to use `s01.oss.sonatype.org` instead of `oss.sonatype.org` including
+   > override the `sonatypeRepository` and `sonatypeCredentialHost` on the root sbt project.
+
  * Related articles:
     * [Deploying to Sonatype - sbt Documentation](http://www.scala-sbt.org/release/docs/Community/Using-Sonatype.html)
     * [Uploading to a Staging Repository via REST API](https://support.sonatype.com/hc/en-us/articles/213465868-Uploading-to-a-Staging-Repository-via-REST-API)
@@ -76,6 +84,10 @@ sonatypeTimeoutMillis := 60 * 60 * 1000
 // [If you cannot use bundle upload] Use this setting when you need to uploads artifacts directly to Sonatype
 // With this setting, you cannot use sonatypeBundleXXX commands
 publishTo := sonatypePublishTo.value
+
+// [If using an account created on or after February 2021] Use the new Sonatype Nexus repository:
+sonatypeCredentialHost := "s01.oss.sonatype.org"
+sonatypeRepository := "https://s01.oss.sonatype.org/service/local"
 ```
 
 ### $HOME/.sbt/(sbt-version 0.13 or 1.0)/sonatype.sbt

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A sbt plugin for publishing your project to the Maven central repository through
 - [Release notes](ReleaseNotes.md)
 - sbt-sonatype is available for sbt 1.x series.
 - You can also use sbt-sonatype for [publishing non-sbt projects](README.md#publishing-maven-projects) (e.g., Maven, Gradle, etc.)
-- [Blazingly Fast Release to Sonatype](https://medium.com/@taroleo/sbt-sonatype-f02bdafd78f1)
+- Blog: [Blazingly Fast Release to Sonatype](https://medium.com/@taroleo/sbt-sonatype-f02bdafd78f1)
 
 ## Prerequisites
 
@@ -28,13 +28,6 @@ A sbt plugin for publishing your project to the Maven central repository through
      * Create a GPG key
      * Open a JIRA ticket to get a permission for synchronizing your project to the Central Repository (aka Maven Central).
 
-   > ⚠️ Legacy Host
-   >
-   > By default, this plugin is configured to use the legacy Sonatype Nexus repository.
-   > Nexus accounts created on or after February 2021 are provisioned using the new host `s01.oss.sonatype.org`.
-   >
-   > If you are creating a new account take care to use `s01.oss.sonatype.org` instead of `oss.sonatype.org` including
-   > override the `sonatypeRepository` and `sonatypeCredentialHost` on the root sbt project.
 
  * Related articles:
     * [Deploying to Sonatype - sbt Documentation](http://www.scala-sbt.org/release/docs/Community/Using-Sonatype.html)
@@ -62,10 +55,20 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 
 ### build.sbt
 
-To use sbt-sonatype, you need to create a bundle of your project artifacts (e.g., .jar, .javadoc, .asc files, etc.) into a local folder specified by `sonatypeBundleDirectory`. By default the folder is `(project root)/target/sonatype-staging/(version)`. Add the following `publishTo` setting to create a local bundle of your project:
+To use sbt-sonatype, you need to create a bundle of your project artifacts (e.g., .jar, .javadoc, .asc files, etc.) into a local folder specified by `sonatypeBundleDirectory`. By default, the folder is `(project root)/target/sonatype-staging/(version)`. Add the following `publishTo` setting to create a local bundle of your project:
 ```scala
 publishTo := sonatypePublishToBundle.value
 ```
+
+  > ⚠️ Legacy Host
+  >
+  > By default, this plugin is configured to use the legacy Sonatype repository `oss.sonatype.org`. If you created a new account on or after February 2021, add `sonatypeCredentialHost` settings:
+  >
+  > ```scala
+  > // For all Sonatype accounts created on or after February 2021
+  > ThisBuild / sonatypeCredentialHost := "s01.oss.sonatype.org"
+  > ```
+
 With this setting, `publishSigned` will create a bundle of your project to the local staging folder. If the project has multiple modules, all of the artifacts will be assembled into the same folder to create a single bundle.
 
 If `isSnapshot.value` is true (e.g., if the version name contains -SNAPSHOT), publishSigned task will upload files to the Sonatype Snapshots repository without using the local bundle folder.
@@ -85,7 +88,7 @@ sonatypeTimeoutMillis := 60 * 60 * 1000
 // With this setting, you cannot use sonatypeBundleXXX commands
 publishTo := sonatypePublishTo.value
 
-// [If using an account created on or after February 2021] Use the new Sonatype Nexus repository:
+// [If necessary] Settings for using custom Nexus repositories:
 sonatypeCredentialHost := "s01.oss.sonatype.org"
 sonatypeRepository := "https://s01.oss.sonatype.org/service/local"
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -49,7 +49,7 @@ lazy val buildSettings: Seq[Setting[_]] = Seq(
   )
 )
 
-val AIRFRAME_VERSION = "21.2.0"
+val AIRFRAME_VERSION = "21.3.0"
 
 // Project modules
 lazy val sbtSonatype =

--- a/src/main/scala/xerial/sbt/Sonatype.scala
+++ b/src/main/scala/xerial/sbt/Sonatype.scala
@@ -52,10 +52,13 @@ object Sonatype extends AutoPlugin with LogSupport {
 
   private implicit val ec = ExecutionContext.global
 
+  val sonatypeLegacy = "oss.sonatype.org"
+  val sonatype01     = "s01.oss.sonatype.org"
+
   lazy val sonatypeSettings = Seq[Def.Setting[_]](
     sonatypeProfileName := organization.value,
-    sonatypeRepository := "https://oss.sonatype.org/service/local",
-    sonatypeCredentialHost := "oss.sonatype.org",
+    sonatypeRepository := s"https://${sonatypeCredentialHost.value}/service/local",
+    sonatypeCredentialHost := sonatypeLegacy,
     sonatypeProjectHosting := None,
     publishMavenStyle := true,
     pomIncludeRepository := { _ =>
@@ -104,7 +107,7 @@ object Sonatype extends AutoPlugin with LogSupport {
       val profileM   = sonatypeTargetRepositoryProfile.?.value
       val repository = sonatypeRepository.value
       val staged = profileM.map { stagingRepoProfile =>
-        "releases" at s"$repository/${stagingRepoProfile.deployPath}"
+        "releases" at s"${repository}/${stagingRepoProfile.deployPath}"
       }
       staged.getOrElse(if (version.value.endsWith("-SNAPSHOT")) {
         Opts.resolver.sonatypeSnapshots

--- a/src/main/scala/xerial/sbt/Sonatype.scala
+++ b/src/main/scala/xerial/sbt/Sonatype.scala
@@ -101,10 +101,10 @@ object Sonatype extends AutoPlugin with LogSupport {
       }
     },
     sonatypeDefaultResolver := {
-      val profileM = sonatypeTargetRepositoryProfile.?.value
-
+      val profileM   = sonatypeTargetRepositoryProfile.?.value
+      val repository = sonatypeRepository.value
       val staged = profileM.map { stagingRepoProfile =>
-        "releases" at stagingRepoProfile.deployUrl
+        "releases" at s"$repository/${stagingRepoProfile.deployPath}"
       }
       staged.getOrElse(if (version.value.endsWith("-SNAPSHOT")) {
         Opts.resolver.sonatypeSnapshots
@@ -154,7 +154,7 @@ object Sonatype extends AutoPlugin with LogSupport {
           val repo       = prepare(state, rest)
           val extracted  = Project.extract(state)
           val bundlePath = extracted.get(sonatypeBundleDirectory)
-          rest.uploadBundle(bundlePath, repo.deployUrl)
+          rest.uploadBundle(bundlePath, repo.deployPath)
           rest.closeAndPromote(repo)
           updatePublishSettings(state, repo)
         }
@@ -169,7 +169,7 @@ object Sonatype extends AutoPlugin with LogSupport {
           val descriptionKey = extracted.get(sonatypeSessionName)
           rest.openOrCreateByKey(descriptionKey)
         }
-        rest.uploadBundle(bundlePath, repo.deployUrl)
+        rest.uploadBundle(bundlePath, repo.deployPath)
         updatePublishSettings(state, repo)
       }
   }

--- a/src/main/scala/xerial/sbt/sonatype/SonatypeClient.scala
+++ b/src/main/scala/xerial/sbt/sonatype/SonatypeClient.scala
@@ -255,7 +255,7 @@ class SonatypeClient(
     httpClient.get[Seq[StagingActivity]](s"${pathPrefix}/staging/repository/${r.repositoryId}/activity")
   }
 
-  def uploadBundle(localBundlePath: File, remoteUrl: String): Unit = {
+  def uploadBundle(localBundlePath: File, deployPath: String): Unit = {
     retryer
       .retryOn {
         case e: IOException if e.getMessage.contains("400 Bad Request") =>
@@ -269,7 +269,7 @@ class SonatypeClient(
       .run {
         val parameters = ParametersBuilder.defaults().build()
         // Adding a trailing slash is necessary upload a bundle file to a proper location:
-        val endpoint      = s"${remoteUrl}/"
+        val endpoint      = s"$repositoryUrl/$deployPath/"
         val clientBuilder = new Hc4ClientBuilder(parameters, endpoint)
 
         val credentialProvider = new BasicCredentialsProvider()
@@ -325,7 +325,7 @@ object SonatypeClient extends LogSupport {
     def toDropped  = copy(`type` = "dropped")
     def toReleased = copy(`type` = "released")
 
-    def deployUrl: String = s"https://oss.sonatype.org/service/local/staging/deployByRepositoryId/${repositoryId}"
+    def deployPath: String = s"staging/deployByRepositoryId/$repositoryId"
   }
 
   case class CreateStageResponse(

--- a/src/main/scala/xerial/sbt/sonatype/SonatypeClient.scala
+++ b/src/main/scala/xerial/sbt/sonatype/SonatypeClient.scala
@@ -268,8 +268,8 @@ class SonatypeClient(
       }
       .run {
         val parameters = ParametersBuilder.defaults().build()
-        // Adding a trailing slash is necessary upload a bundle file to a proper location:
-        val endpoint      = s"$repositoryUrl/$deployPath/"
+        // Adding a trailing slash is necessary to upload a bundle file to a proper location:
+        val endpoint      = s"${repositoryUrl}/${deployPath}/"
         val clientBuilder = new Hc4ClientBuilder(parameters, endpoint)
 
         val credentialProvider = new BasicCredentialsProvider()
@@ -325,7 +325,7 @@ object SonatypeClient extends LogSupport {
     def toDropped  = copy(`type` = "dropped")
     def toReleased = copy(`type` = "released")
 
-    def deployPath: String = s"staging/deployByRepositoryId/$repositoryId"
+    def deployPath: String = s"staging/deployByRepositoryId/${repositoryId}"
   }
 
   case class CreateStageResponse(

--- a/src/main/scala/xerial/sbt/sonatype/SonatypeService.scala
+++ b/src/main/scala/xerial/sbt/sonatype/SonatypeService.scala
@@ -66,8 +66,8 @@ class SonatypeService(
   def openRepositories   = stagingRepositoryProfiles().filter(_.isOpen).sortBy(_.repositoryId)
   def closedRepositories = stagingRepositoryProfiles().filter(_.isClosed).sortBy(_.repositoryId)
 
-  def uploadBundle(localBundlePath: File, remoteUrl: String): Unit = {
-    sonatypClient.uploadBundle(localBundlePath, remoteUrl)
+  def uploadBundle(localBundlePath: File, deployPath: String): Unit = {
+    sonatypClient.uploadBundle(localBundlePath, deployPath)
   }
 
   def openOrCreateByKey(descriptionKey: String): StagingRepositoryProfile = {


### PR DESCRIPTION
This fixes the workaround for https://github.com/xerial/sbt-sonatype/issues/214 although doesn't fix that issue completely.

In order to support both Sonatype URLs I think this ought to first try `oss.sonatype.org` and then fallback to `s01.oss.sonatype.org`.

In any case it should still be possible to override the URL manually which this PR enables.