### PR TITLE
Fix: Remove unnecessary sonatypeCredentialHost change.

### DIFF
--- a/src/main/scala/xerial/sbt/Sonatype.scala
+++ b/src/main/scala/xerial/sbt/Sonatype.scala
@@ -61,6 +61,7 @@ object Sonatype extends AutoPlugin with LogSupport {
   lazy val sonatypeSettings = Seq[Def.Setting[_]](
     sonatypeProfileName := organization.value,
     sonatypeRepository := s"https://${sonatypeCredentialHost.value}/service/local",
+    sonatypeCredentialHost := Option(sonatypeCredentialHost.value).getOrElse(sonatypeLegacy),
     sonatypeProjectHosting := None,
     publishMavenStyle := true,
     pomIncludeRepository := { _ =>

--- a/src/main/scala/xerial/sbt/Sonatype.scala
+++ b/src/main/scala/xerial/sbt/Sonatype.scala
@@ -61,7 +61,6 @@ object Sonatype extends AutoPlugin with LogSupport {
   lazy val sonatypeSettings = Seq[Def.Setting[_]](
     sonatypeProfileName := organization.value,
     sonatypeRepository := s"https://${sonatypeCredentialHost.value}/service/local",
-    sonatypeCredentialHost := sonatypeLegacy,
     sonatypeProjectHosting := None,
     publishMavenStyle := true,
     pomIncludeRepository := { _ =>


### PR DESCRIPTION
Remove unnecessary sonatypeCredentialHost  Resetting it to sonatypeLegacy will fail the authorisation for repos which are created after feb 2021