### PR TITLE
Scope sonatypeCredentialHost to the build instead of projects.

### DIFF
--- a/src/main/scala/xerial/sbt/Sonatype.scala
+++ b/src/main/scala/xerial/sbt/Sonatype.scala
@@ -49,6 +49,7 @@ object Sonatype extends AutoPlugin with LogSupport {
 
   override def trigger         = allRequirements
   override def projectSettings = sonatypeSettings
+  override def buildSettings   = sonatypeBuildSettings
 
   import autoImport._
   import complete.DefaultParsers._
@@ -58,10 +59,12 @@ object Sonatype extends AutoPlugin with LogSupport {
   val sonatypeLegacy = "oss.sonatype.org"
   val sonatype01     = "s01.oss.sonatype.org"
 
+  lazy val sonatypeBuildSettings = Seq[Def.Setting[_]](
+    sonatypeCredentialHost := sonatypeLegacy
+  )
   lazy val sonatypeSettings = Seq[Def.Setting[_]](
     sonatypeProfileName := organization.value,
     sonatypeRepository := s"https://${sonatypeCredentialHost.value}/service/local",
-    sonatypeCredentialHost := sonatypeLegacy,
     sonatypeProjectHosting := None,
     publishMavenStyle := true,
     pomIncludeRepository := { _ =>


### PR DESCRIPTION
Previously, the `sonatypeCredentialHost` setting had to be redefined
inside every project even if the sbt-sonatype readme documents that
the setting can be configured once via `ThisBuild /` at the root of
build.sbt. This commit moves the definition of that setting to the build
scope so that the behavior is consistent with the documentation.

Related https://github.com/olafurpg/sbt-ci-release/issues/173