### PR TITLE
Use unique names for resolvers

### DIFF
--- a/src/main/scala/xerial/sbt/Sonatype.scala
+++ b/src/main/scala/xerial/sbt/Sonatype.scala
@@ -114,13 +114,13 @@ object Sonatype extends AutoPlugin with LogSupport {
     },
     sonatypeSnapshotResolver := {
       MavenRepository(
-        "sonatype-snapshots",
+        s"${sonatypeCredentialHost.value.replace('.', '-')}-snapshots",
         s"https://${sonatypeCredentialHost.value}/content/repositories/snapshots"
       )
     },
     sonatypeStagingResolver := {
       MavenRepository(
-        "sonatype-staging",
+        s"${sonatypeCredentialHost.value.replace('.', '-')}-staging",
         s"https://${sonatypeCredentialHost.value}/service/local/staging/deploy/maven2"
       )
     },
@@ -128,7 +128,7 @@ object Sonatype extends AutoPlugin with LogSupport {
       val profileM   = sonatypeTargetRepositoryProfile.?.value
       val repository = sonatypeRepository.value
       val staged = profileM.map { stagingRepoProfile =>
-        "releases" at s"${repository}/${stagingRepoProfile.deployPath}"
+        s"${sonatypeCredentialHost.value.replace('.', '-')}-releases" at s"${repository}/${stagingRepoProfile.deployPath}"
       }
       staged.getOrElse(if (version.value.endsWith("-SNAPSHOT")) {
         sonatypeSnapshotResolver.value


### PR DESCRIPTION
I just ran into a strange bug. The project was configured to publish with `sonatypeCredentialHost := "s01.oss.sonatype.org"`, but for some reason was publishing to `oss.sonatype.org` instead. The error message gave this clue:

```
Multiple resolvers having different access mechanism configured with same name 'sonatype-snapshots'. To avoid conflict, Remove duplicate project resolvers (`resolvers`) or rename publishing resolver (`publishTo`).
```

In its `build.sbt` this project had:
```scala
resolvers += Resolver.sonatypeRepo("snapshots")
```

Which adds the `oss.sonatype.org` snapshots repository to the resolvers under the name "sonatype-snapshots".
```scala
  def sonatypeRepo(status: String) =
    MavenRepository(
      "sonatype-" + status,
      if (status == "releases") SonatypeReleasesRepository
      else SonatypeRepositoryRoot + "/" + status
    )
```
https://github.com/sbt/librarymanagement/blob/67988135152f88afa9134fcfc357c0901e700f40/core/src/main/scala/sbt/librarymanagement/ResolverExtra.scala#L156-L161

The problem is that sbt-sonatype adds the `s01.oss.sonatype.org` snapshots repository under the same name:
https://github.com/xerial/sbt-sonatype/blob/91e5626fdeff25e6dbd9eafffe3a476fddc3dcba/src/main/scala/xerial/sbt/Sonatype.scala#L115-L119

This PR ensures that the resolvers added by sbt-sonatype have unique names. Personally I don't have any preference what the resolver names are so I'm happy to change them as you see fit, so long as they are unique. What I chose here is a simple substitution so that `oss.sonatype.org` becomes `oss-sonatype-org` and `s01.oss.sonatype.org` becomes `s01-oss-sonatype-org`.

Thanks for your attention to this!