### PR TITLE
Output sonatype client logs to target/sbt-sonatype folder

### DIFF
--- a/src/main/scala/xerial/sbt/sonatype/SonatypeClient.scala
+++ b/src/main/scala/xerial/sbt/sonatype/SonatypeClient.scala
@@ -63,8 +63,9 @@ class SonatypeClient(
 
   private[sonatype] val clientConfig = {
     Http.client
+      .withName("sonatype-client")
       // Put the log file under target/sbt-sonatype directory
-      .withLoggerConfig(_.withLogFileName("target/sbt-sonatype/http_client.json"))
+      .withLoggerConfig(_.withLogFileName("target/sbt-sonatype/sonatype_client_logs.json"))
       // Disables the circuit breaker, because Sonatype can be down for a long time https://github.com/xerial/sbt-sonatype/issues/363
       .noCircuitBreaker
       // Use URLConnectionClient for JDK8 compatibility. Remove this line when using JDK11 or later

--- a/src/main/scala/xerial/sbt/sonatype/SonatypeClient.scala
+++ b/src/main/scala/xerial/sbt/sonatype/SonatypeClient.scala
@@ -63,6 +63,8 @@ class SonatypeClient(
 
   private[sonatype] val clientConfig = {
     Http.client
+      // Put the log file under target/sbt-sonatype directory
+      .withLoggerConfig(_.withLogFileName("target/sbt-sonatype/http_client.json"))
       // Disables the circuit breaker, because Sonatype can be down for a long time https://github.com/xerial/sbt-sonatype/issues/363
       .noCircuitBreaker
       // Use URLConnectionClient for JDK8 compatibility. Remove this line when using JDK11 or later


### PR DESCRIPTION
- Use target folder for http logging
- Set client name
