### PR TITLE
feature: Give helpful advice when profile missing on host

### DIFF
--- a/src/main/scala/xerial/sbt/Sonatype.scala
+++ b/src/main/scala/xerial/sbt/Sonatype.scala
@@ -59,6 +59,7 @@ object Sonatype extends AutoPlugin with LogSupport {
 
   val sonatypeLegacy = "oss.sonatype.org"
   val sonatype01     = "s01.oss.sonatype.org"
+  val KnownOssHosts  = Seq(sonatypeLegacy, sonatype01)
 
   lazy val sonatypeBuildSettings = Seq[Def.Setting[_]](
     sonatypeCredentialHost := sonatypeLegacy

--- a/src/main/scala/xerial/sbt/Sonatype.scala
+++ b/src/main/scala/xerial/sbt/Sonatype.scala
@@ -59,7 +59,7 @@ object Sonatype extends AutoPlugin with LogSupport {
 
   val sonatypeLegacy = "oss.sonatype.org"
   val sonatype01     = "s01.oss.sonatype.org"
-  val KnownOssHosts  = Seq(sonatypeLegacy, sonatype01)
+  val knownOssHosts  = Seq(sonatypeLegacy, sonatype01)
 
   lazy val sonatypeBuildSettings = Seq[Def.Setting[_]](
     sonatypeCredentialHost := sonatypeLegacy

--- a/src/main/scala/xerial/sbt/sonatype/SonatypeException.scala
+++ b/src/main/scala/xerial/sbt/sonatype/SonatypeException.scala
@@ -1,5 +1,7 @@
 package xerial.sbt.sonatype
 
+import xerial.sbt.Sonatype
+
 /** An exception used for showing only an error message when there is no need to show stack traces
   */
 case class SonatypeException(errorCode: ErrorCode, message: String) extends Exception(message) {
@@ -20,7 +22,18 @@ object SonatypeException {
 
   case object MISSING_STAGING_PROFILE extends ErrorCode
 
-  case object MISSING_PROFILE extends ErrorCode
+  case class MISSING_PROFILE(profileName: String, host: String) extends ErrorCode {
+    val problem = s"Profile $profileName is not found on $host"
+
+    val possibleAlternativeHosts: Seq[String] = Sonatype.KnownOssHosts.filterNot(_ == host)
+
+    val hostAdvice = s"try ${possibleAlternativeHosts.mkString(", or ")}?"
+
+    val advice: String =
+      s"In your sbt settings, check your sonatypeProfileName and sonatypeCredentialHost ($hostAdvice)"
+
+    val message: String = s"$problem. $advice"
+  }
 
   case object UNKNOWN_STAGE extends ErrorCode
 

--- a/src/main/scala/xerial/sbt/sonatype/SonatypeException.scala
+++ b/src/main/scala/xerial/sbt/sonatype/SonatypeException.scala
@@ -23,16 +23,13 @@ object SonatypeException {
   case object MISSING_STAGING_PROFILE extends ErrorCode
 
   case class MISSING_PROFILE(profileName: String, host: String) extends ErrorCode {
-    val problem = s"Profile $profileName is not found on $host"
-
-    val possibleAlternativeHosts: Seq[String] = Sonatype.KnownOssHosts.filterNot(_ == host)
-
-    val hostAdvice = s"try ${possibleAlternativeHosts.mkString(", or ")}?"
-
-    val advice: String =
+    def problem                               = s"Profile ${profileName} is not found on ${host}"
+    def possibleAlternativeHosts: Seq[String] = Sonatype.knownOssHosts.filterNot(_ == host)
+    def hostAdvice                            = s"try ${possibleAlternativeHosts.mkString(", or ")}?"
+    def advice: String =
       s"In your sbt settings, check your sonatypeProfileName and sonatypeCredentialHost ($hostAdvice)"
 
-    val message: String = s"$problem. $advice"
+    def message: String = s"${problem}. ${advice}"
   }
 
   case object UNKNOWN_STAGE extends ErrorCode

--- a/src/main/scala/xerial/sbt/sonatype/SonatypeService.scala
+++ b/src/main/scala/xerial/sbt/sonatype/SonatypeService.scala
@@ -6,6 +6,7 @@ import java.io.File
 import sbt.io.IO
 import wvlet.airframe.codec.MessageCodecFactory
 import wvlet.log.LogSupport
+import xerial.sbt.Sonatype
 import xerial.sbt.sonatype.SonatypeClient.*
 import xerial.sbt.sonatype.SonatypeException.{MISSING_PROFILE, MISSING_STAGING_PROFILE, MULTIPLE_TARGETS, UNKNOWN_STAGE}
 
@@ -151,10 +152,8 @@ class SonatypeService(
   lazy val currentProfile: StagingProfile = {
     val profiles = stagingProfiles
     if (profiles.isEmpty) {
-      throw SonatypeException(
-        MISSING_PROFILE,
-        s"Profile ${profileName} is not found. Check your sonatypeProfileName setting in build.sbt"
-      )
+      val error = MISSING_PROFILE(profileName, sonatypClient.repoUri.getHost)
+      throw SonatypeException(error, error.message)
     }
     profiles.head
   }

--- a/src/test/scala/xerial/sbt/sonatype/SonatypeExceptionTest.scala
+++ b/src/test/scala/xerial/sbt/sonatype/SonatypeExceptionTest.scala
@@ -1,0 +1,17 @@
+package xerial.sbt.sonatype
+
+import wvlet.airspec.AirSpec
+import xerial.sbt.sonatype.SonatypeException.MISSING_PROFILE;
+
+class SonatypeExceptionTest extends AirSpec {
+  test("give helpful advice when no profile is found") {
+    val missingProfile = MISSING_PROFILE("com.gu", "oss.sonatype.org")
+    missingProfile.problem shouldBe "Profile com.gu is not found on oss.sonatype.org"
+    missingProfile.possibleAlternativeHosts shouldBe Seq("s01.oss.sonatype.org")
+    missingProfile.advice shouldBe
+      "In your sbt settings, check your sonatypeProfileName and sonatypeCredentialHost (try s01.oss.sonatype.org?)"
+
+    MISSING_PROFILE("com.gu", "s01.oss.sonatype.org").hostAdvice shouldBe "try oss.sonatype.org?"
+    MISSING_PROFILE("com.gu", "example.com").hostAdvice shouldBe "try oss.sonatype.org, or s01.oss.sonatype.org?"
+  }
+}


### PR DESCRIPTION
This updates the error message given when a profile is not found on a host (note Sonatype currently has 2 OSS hosts - `oss.sonatype.org` & `s01.oss.sonatype.org` - and any profile will only exist on _one_ of the hosts).

<img width="1331" alt="image" src="https://github.com/xerial/sbt-sonatype/assets/52038/8b3d8ce9-5c2c-4c7b-8f48-3631f161e59b">

_(example [here](https://github.com/rtyley/sample-project-using-gha-scala-library-release-workflow/actions/runs/7328552302/job/19957061322#step:5:28))_

There can be two possible causes when a profile is not found on a host:

1. The profile name is misspelt/incorrect (eg 'com.gnu' or 'john.smith' instead of 'com.gu')
2. The profile is actually on the _other_ Sonatype OSS host

The original error message really only indicated the possibility of the _1st_ problem, but the 2nd issue is increasingly likely - since [February 2021](https://central.sonatype.org/news/20210223_new-users-on-s01/) new profiles have _only_ been registered on the new host `s01.oss.sonatype.org`, and `sbt-sonatype` defaults to using the older host, `oss.sonatype.org`.

The new error message aims to make the user aware of the 2 possible causes of the 'missing profile' problem, and offer advice on how the 2nd problem could be corrected.

Before:

> Profile com.gu is not found. Check your sonatypeProfileName setting in build.sbt

After:

> Profile com.gu is not found on oss.sonatype.org. In your sbt settings, check your sonatypeProfileName and sonatypeCredentialHost (try s01.oss.sonatype.org?)"

### Sonatype host is determined by-profile (_not_ by-user)

Note that in the [past](https://github.com/xerial/sbt-sonatype/issues/273), there's been a bit of confusion (ok, _I've_ been a bit confused!) about whether hosts are assigned on a by-user or by-profile basis (many users can be granted access by Sonatype to upload to one profile, eg we at the Guardian have that for our com.gu profile). It's definitely [per-profile](https://github.com/xerial/sbt-sonatype/issues/273#issuecomment-997486538) though - so `sonatypeProfileName` dictates which `sonatypeCredentialHost` you want to be using.

As a user (eg, for me, with my Sonatype user account 'roberto') working on a variety of projects with different profiles (eg, for me, working on projects under `com.gu`, `com.madgag` & `org.scanamo`) when I'm performing a release I'll be uploading to either `oss.sonatype.org`, _or_ `s01.oss.sonatype.org`, depending on which profile/groupId that particular project lives under.