### PR TITLE
Use isSnapshot in place of "-SNAPSHOT" suffix check

### DIFF
--- a/src/main/scala/xerial/sbt/Sonatype.scala
+++ b/src/main/scala/xerial/sbt/Sonatype.scala
@@ -105,7 +105,7 @@ object Sonatype extends AutoPlugin with LogSupport {
       IO.delete(sonatypeBundleDirectory.value)
     },
     sonatypePublishToBundle := {
-      if (version.value.endsWith("-SNAPSHOT")) {
+      if (isSnapshot.value) {
         // Sonatype snapshot repositories have no support for bundle upload,
         // so use direct publishing to the snapshot repo.
         Some(sonatypeSnapshotResolver.value)


### PR DESCRIPTION
Use isSnapshot instead of the "-SNAPSHOT" hardcoded. Plugins like sbt-dynver generate version that don't end with -SNAPSHOT but are still snapshots.