### PR TITLE
Fix computation of sonatypeDefaultResolver for Sonatype Central

### DIFF
--- a/src/main/scala/xerial/sbt/Sonatype.scala
+++ b/src/main/scala/xerial/sbt/Sonatype.scala
@@ -141,7 +141,7 @@ object Sonatype extends AutoPlugin with LogSupport {
     },
     sonatypeDefaultResolver := {
       if (sonatypeCredentialHost.value == SonatypeCentralClient.host) {
-        Resolver.url(s"https://$sonatypeCredentialHost")
+        Resolver.url(s"https://${sonatypeCredentialHost.value}")
       } else {
         val profileM   = sonatypeTargetRepositoryProfile.?.value
         val repository = sonatypeRepository.value

--- a/src/sbt-test/sbt-sonatype/sonatype-central-host/build.sbt
+++ b/src/sbt-test/sbt-sonatype/sonatype-central-host/build.sbt
@@ -1,0 +1,8 @@
+sonatypeCredentialHost := xerial.sbt.sonatype.SonatypeCentralClient.host
+
+val checkSonatypeDefaultResolver = taskKey[Unit]("Check if the default resolver is Sonatype")
+checkSonatypeDefaultResolver := {
+  val actual   = sonatypeDefaultResolver.value
+  val expected = Resolver.url("https://central.sonatype.com")
+  require(actual == expected, s"expected $actual to be $expected")
+}

--- a/src/sbt-test/sbt-sonatype/sonatype-central-host/project/plugins.sbt
+++ b/src/sbt-test/sbt-sonatype/sonatype-central-host/project/plugins.sbt
@@ -1,0 +1,8 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if (pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else
+    addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % pluginVersion)
+}

--- a/src/sbt-test/sbt-sonatype/sonatype-central-host/test
+++ b/src/sbt-test/sbt-sonatype/sonatype-central-host/test
@@ -1,0 +1,1 @@
+> checkSonatypeDefaultResolver


### PR DESCRIPTION
Without the main change, the test fails:

```
[info] [error] (checkSonatypeDefaultResolver) java.lang.IllegalArgumentException: requirement failed: expected URLRepository(https://SettingKey(This / This / This / sonatypeCredentialHost), Patterns(ivyPatterns=Vector(), artifactPatterns=Vector(), isMavenCompatible=false, descriptorOptional=false, skipConsistencyCheck=false), false) to be URLRepository(https://central.sonatype.com, Patterns(ivyPatterns=Vector(), artifactPatterns=Vector(), isMavenCompatible=false, descriptorOptional=false, skipConsistencyCheck=false), false)
```

Notably:

```
https://SettingKey(This / This / This / sonatypeCredentialHost)
vs
https://central.sonatype.com
```