### PR TITLE
Document you need a token since Jan 2024

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,13 +116,13 @@ sonatypeRepository := "https://s01.oss.sonatype.org/service/local"
 
 ### $HOME/.sbt/(sbt-version 0.13 or 1.0)/sonatype.sbt
 
-For the authentication to Sonatype API, you need to set your Sonatype account information (user name and password) in the global sbt settings. To protect your password, never include this file within your project.
+For the authentication to Sonatype API, you need to set your Sonatype token information (name and password) in the global sbt settings. To protect your password, never include this file within your project. Get the token from https://oss.sonatype.org or https://s01.oss.sonatype.org.
 
 ```scala
 credentials += Credentials("Sonatype Nexus Repository Manager",
         "oss.sonatype.org",
-        "(Sonatype user name)",
-        "(Sonatype password)")
+        "(Sonatype token user name)",
+        "(Sonatype token password)")
 ```
 
 ### (project root)/sonatype.sbt


### PR DESCRIPTION
Since Jan 2024 you need to authenticate with a token instead of your username/password.