### PR TITLE
readme: note re sbt plugins on sonatype central

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ import xerial.sbt.Sonatype.sonatypeCentralHost
 
 ThisBuild / sonatypeCredentialHost := sonatypeCentralHost
 ```
+Note: if you are publishing an sbt plugin you will also need to configure `sbtPluginPublishLegacyMavenStyle := false` for that project. 
+Context: sbt publishes plugins with file names that do not conform to the maven specification. Sonatype OSSRH didn't validate this, but Sonatype Central does: `File name 'sbt-my-plugin-0.0.1.jar' is not valid`. 
+See also: https://github.com/sbt/sbt/issues/3410
+
 
 #### Usage
 


### PR DESCRIPTION
publishing sbt plugins to sonatype central requires a workaround

See also: https://github.com/sbt/sbt/issues/3410