### PR TITLE
SyncSonatypeClient: configure read timeout

### DIFF
--- a/src/main/scala/xerial/sbt/Sonatype.scala
+++ b/src/main/scala/xerial/sbt/Sonatype.scala
@@ -477,7 +477,7 @@ object Sonatype extends AutoPlugin with LogSupport {
     val eitherOp = for {
       client <- SonatypeCentralClient.fromCredentials(
         credentials,
-        readTimeoutMillis = extracted.get(sonatypeTimeoutMillis)
+        readTimeoutMillis = extracted.get(sonatypeTimeoutMillis).toLong
       )
       service = new SonatypeCentralService(client)
       res <-

--- a/src/main/scala/xerial/sbt/Sonatype.scala
+++ b/src/main/scala/xerial/sbt/Sonatype.scala
@@ -473,9 +473,12 @@ object Sonatype extends AutoPlugin with LogSupport {
     wvlet.log.Logger.setDefaultLogLevel(logLevel)
 
     val credentials = getCredentials(extracted, state)
-
+     
     val eitherOp = for {
-      client <- SonatypeCentralClient.fromCredentials(credentials)
+      client <- SonatypeCentralClient.fromCredentials(
+        credentials,
+        readTimeoutMillis = extracted.get(sonatypeTimeoutMillis)
+      )
       service = new SonatypeCentralService(client)
       res <-
         try {

--- a/src/main/scala/xerial/sbt/Sonatype.scala
+++ b/src/main/scala/xerial/sbt/Sonatype.scala
@@ -473,7 +473,7 @@ object Sonatype extends AutoPlugin with LogSupport {
     wvlet.log.Logger.setDefaultLogLevel(logLevel)
 
     val credentials = getCredentials(extracted, state)
-     
+
     val eitherOp = for {
       client <- SonatypeCentralClient.fromCredentials(
         credentials,

--- a/src/main/scala/xerial/sbt/sonatype/SonatypeCentralClient.scala
+++ b/src/main/scala/xerial/sbt/sonatype/SonatypeCentralClient.scala
@@ -25,7 +25,8 @@ import xerial.sbt.sonatype.utils.Extensions.*
 import xerial.sbt.sonatype.SonatypeException.{BUNDLE_UPLOAD_FAILURE, STATUS_CHECK_FAILURE, USER_ERROR}
 
 private[sonatype] class SonatypeCentralClient(
-    client: SyncSonatypeClient
+    client: SyncSonatypeClient,
+    readTimeoutMillis: Long
 ) extends AutoCloseable
     with LogSupport {
 
@@ -86,7 +87,7 @@ private[sonatype] class SonatypeCentralClient(
 
     for {
       response <- retryRequest(
-        client.checkStatus(deploymentId)(asJson[CheckStatusResponse]).body,
+        client.checkStatus(deploymentId, timeout = readTimeoutMillis)(asJson[CheckStatusResponse]).body,
         "Error checking deployment status",
         STATUS_CHECK_FAILURE,
         10
@@ -118,7 +119,7 @@ private[sonatype] class SonatypeCentralClient(
 object SonatypeCentralClient {
   val host: String = "central.sonatype.com"
 
-  def fromCredentials(credentials: Seq[Credentials]): Either[SonatypeException, SonatypeCentralClient] =
+  def fromCredentials(credentials: Seq[Credentials], readTimeoutMillis: Long): Either[SonatypeException, SonatypeCentralClient] =
     for {
       sonatypeCredentials <- SonatypeCredentials.fromEnv(credentials, host)
       backend = Slf4jLoggingBackend(HttpURLConnectionBackend())
@@ -127,5 +128,5 @@ object SonatypeCentralClient {
         backend,
         Some(LoggingOptions(logRequestBody = Some(true), logResponseBody = Some(true)))
       )
-    } yield new SonatypeCentralClient(client)
+    } yield new SonatypeCentralClient(client, readTimeoutMillis)
 }

--- a/src/main/scala/xerial/sbt/sonatype/SonatypeCentralClient.scala
+++ b/src/main/scala/xerial/sbt/sonatype/SonatypeCentralClient.scala
@@ -119,7 +119,10 @@ private[sonatype] class SonatypeCentralClient(
 object SonatypeCentralClient {
   val host: String = "central.sonatype.com"
 
-  def fromCredentials(credentials: Seq[Credentials], readTimeoutMillis: Long): Either[SonatypeException, SonatypeCentralClient] =
+  def fromCredentials(
+      credentials: Seq[Credentials],
+      readTimeoutMillis: Long
+  ): Either[SonatypeException, SonatypeCentralClient] =
     for {
       sonatypeCredentials <- SonatypeCredentials.fromEnv(credentials, host)
       backend = Slf4jLoggingBackend(HttpURLConnectionBackend())


### PR DESCRIPTION
It defaults to 5s, which often fails for our builds recently. sbt-sonatype already has a configurable timeout, so we're just passing that value on here.

Example for a failure:
```
2025-03-20 11:38:44.040Z  info [SonatypeCentralClient] Uploading bundle /home/runner/work/joern/joern/target/sonatype-staging/4.0.299-bundle/bundle.zip to Sonatype Central  - (SonatypeCentralClient.scala:72)
2025-03-20 11:38:47.814Z  info [SonatypeCentralService] Checking if deployment succeeded for deployment id: 583c03d8-b0cb-431f-b3d5-a7990a1e435d...  - (SonatypeCentralService.scala:27)
11:54:06.356 [main] ERROR sttp.client4.logging.slf4j.Slf4jLoggingBackend - Exception when sending request: POST https://central.sonatype.com/api/v1/publisher/status?id=583c03d8-b0cb-431f-b3d5-a7990a1e435d, took: 5.085s
sttp.client4.SttpClientException$TimeoutException: Exception when sending request: POST https://central.sonatype.com/api/v1/publisher/status?id=583c03d8-b0cb-431f-b3d5-a7990a1e435d
	at sttp.client4.SttpClientExceptionExtensions.defaultExceptionToSttpClientException(SttpClientExceptionExtensions.scala:21) ~[?:?]
```

https://github.com/joernio/joern/actions/runs/13967737826/job/39101942676