### PR TITLE
Default to central host in credentials config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ For the authentication to Sonatype API, you need to set your Sonatype token info
 
 ```scala
 credentials += Credentials("Sonatype Nexus Repository Manager",
-        "oss.sonatype.org",
+        "central.sonatype.com",    // or "oss.sonatype.org" when using a legacy host
         "(Sonatype token user name)",
         "(Sonatype token password)")
 ```


### PR DESCRIPTION
When a credentials file is used, the host name much match the used sonatype host. Now that Sonatype is deprecating the legacy hosts, the central host should be the default and the legacy host just a comment.